### PR TITLE
fix workshop page content

### DIFF
--- a/_data/data.csv
+++ b/_data/data.csv
@@ -1,2 +1,2 @@
 venue,address,country,latitude,longitude,humandate,humantime,startdate,enddate,instructor,helper,carpentry,curriculum,title,slug,flavor
-"WDCC, Wageningen","WDCC, WUR, Wageningen",NA,NA,NA,"November 28 - 28, 2022",9:30 - 17:00 CET,2022-11-27T23:00:00Z,2022-11-27T23:00:00Z,"Sven van der Burg, Ole Mussmann",,ds,NA,Collaborative Version Control with Git and Gitlab,2022-11-28-wdcc-git,NA
+"WDCC, Wageningen","WDCC, WUR, Wageningen",NA,NA,NA,"November 28, 2022",9:30 - 17:00 CET,2022-11-27T23:00:00Z,2022-11-27T23:00:00Z,"Sven van der Burg, Ole Mussmann",,ds,NA,Collaborative Version Control with Git and GitLab,2022-11-28-wdcc-git,NA

--- a/index.md
+++ b/index.md
@@ -77,7 +77,7 @@ AUDIENCE
 Explain who your audience is.  (In particular, tell readers if the
 workshop is only open to people from a particular institution.
 {% endcomment %}
-This workshop is only open to people from Wageningen Digital Competence Center
+This workshop is only open to people from Wageningen Data Competence Center
 
 {% comment %}
 DATE
@@ -240,10 +240,10 @@ of code below the Schedule `<h2>` header below with
 * Tracking changes
 * Exploring history
 * Ignoring things
-* Gitlab remotes
+* GitLab remotes
 * Conflicts
-* Centralized workflow with Git and Gitlab
-* Distributed workflow with Git and Gitlab
+* Centralized workflow with Git and GitLab
+* Distributed workflow with Git and GitLab
 
 <h2 id="schedule">Schedule</h2>
 
@@ -263,7 +263,8 @@ of code below the Schedule `<h2>` header below with
       <tr> <td>15:30</td>  <td>Coffee break</td> </tr>
       <tr> <td>15:40</td>  <td>Distributed workflow with Git and GitLab</td> </tr>
       <tr> <td>16:15</td>  <td>Wrap-up</td> </tr>
-      <tr> <td>16:30</td>  <td>END</td> </tr>
+      <tr> <td>16:30</td>  <td>Questions and discussions</td> </tr>
+      <tr> <td>17:00</td>  <td>END</td> </tr>
     </tbody></table>
   </div>
 </div>
@@ -320,5 +321,5 @@ during the workshop.
 <ul>
   <li>Install Shell and Git. Please refer to <a href="https://coderefinery.github.io/installation/shell-and-git/">this page</a> for installation instructions.</li>
   <li>Create a GitLab account. Please refer to <a href="https://gitlab.com/users/sign_up">this page</a> for instructions.</li>
-  <li>Set up an SSH connection to GitLab. First [check if you have an ssh key](https://docs.gitlab.com/ee/user/ssh.html#see-if-you-have-an-existing-ssh-key-pair). Then create an SSH key pair if you don't have one, please refer to <a href="https://docs.gitlab.com/ee/user/ssh.html#generate-an-ssh-key-pair">this page</a> for instructions. Then add the SSH key to your GitLab account following <a href="https://docs.gitlab.com/ee/user/ssh.html#add-an-ssh-key-to-your-gitlab-account">these instructions</a></li>
+  <li>Set up an SSH connection to GitLab. First <a href="https://docs.gitlab.com/ee/user/ssh.html#see-if-you-have-an-existing-ssh-key-pair">check if you have an ssh key</a>. Then create an SSH key pair if you don't have one, please refer to <a href="https://docs.gitlab.com/ee/user/ssh.html#generate-an-ssh-key-pair">this page</a> for instructions. Then add the SSH key to your GitLab account following <a href="https://docs.gitlab.com/ee/user/ssh.html#add-an-ssh-key-to-your-gitlab-account">these instructions</a></li>
 </ul>


### PR DESCRIPTION
### Fix for the following items
- Gitlab -> GitLab
- Tweak date format 28-28 -> 28
- Wageningen Digital Competence Center -> Wageningen Data Competence Center
- Fix broken SSH key link

### Discussion points
- End times do not match, title says 17:00, agenda says 16:00. I added half an hour "Questions and Discussion" at the end, I don't know if that's a good idea.
- Ideally I'd like to have the WDCC address on the page (also for myself later), but I could not find it. Do you have it somewhere?
- I can't include the helpers yet, I don't know their names yet.
- We don't have prerequisites (background knowledge) listed. Should we add some?
- There's no eventbrite code, but that's correct, right?